### PR TITLE
Fix Renovate schedules and restore automatic updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,12 @@
     ":enableVulnerabilityAlerts"
   ],
   "timezone": "Europe/Rome",
-  "schedule": ["before 6am on Monday"],
+  "schedule": ["* 0-5 * * 1"],
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
   "branchConcurrentLimit": 5,
   "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "automergeType": "pr",
   "platformAutomerge": false,
   "ignoreTests": false,
@@ -28,7 +29,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on the first Monday of the month"],
+    "schedule": ["* 0-3 1 * *"],
     "automerge": true
   },
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Renovate stopped opening dependency PRs because the textual monthly schedule was invalid.

This patch:

- replaces both textual schedules with Renovate's recommended five-field cron syntax;
- checks weekly during the early Monday window in Europe/Rome;
- performs lockfile maintenance on the first day of each month before 04:00;
- enables strict internal age checks so seven-day release aging does not create premature branches or PRs;
- preserves immediate vulnerability-alert processing and CI-gated automerge behavior.