### PR TITLE
Make AWS migration atomic and automatically recover production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ env:
   AWS_DEPLOY_ROLE_ARN: arn:aws:iam::590183760311:role/GitHubActions-ToEnWikipediaBot
   AWS_RETRY_MODE: standard
   AWS_MAX_ATTEMPTS: "10"
+  LAST_KNOWN_GOOD_COMMIT: 28dd94002753075a9fab0f5bd7f3d342a84e04d8
 
 jobs:
   test:
@@ -64,11 +65,13 @@ jobs:
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     environment: production
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -136,25 +139,35 @@ jobs:
             echo "::warning title=GitHub OIDC migration deferred::Deployment is continuing with the existing AWS secrets. Reliability and monitoring rollout is not blocked; IAM/OIDC can be completed separately."
           fi
 
-      - name: Build Lambda packages with the runtime Python version
+      - name: Build new, monitor, and rollback Lambda packages
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip boto3
+          rm -rf package monitor-package legacy-package
           mkdir -p package monitor-package
           python -m pip install --only-binary=:all: -r requirements.txt -t package
           cp ToEnWikipediaBot.py package/
           (cd package && zip -q -r ../package.zip .)
+
           cp monitor.py monitor-package/
           (cd monitor-package && zip -q -r ../monitor-package.zip .)
 
-      - name: Deploy bot code
+          cp -a package legacy-package
+          git show "${LAST_KNOWN_GOOD_COMMIT}:ToEnWikipediaBot.py" > legacy-package/ToEnWikipediaBot.py
+          (cd legacy-package && zip -q -r ../legacy-package.zip .)
+
+      - name: Restore authenticated known-good service before migration
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
         run: |
           aws lambda update-function-code \
-            --function-name "${{ secrets.LAMBDA_FUNCTION_NAME }}" \
-            --zip-file fileb://package.zip
+            --function-name "${LAMBDA_FUNCTION_NAME}" \
+            --zip-file fileb://legacy-package.zip
           aws lambda wait function-updated-v2 \
-            --function-name "${{ secrets.LAMBDA_FUNCTION_NAME }}"
+            --function-name "${LAMBDA_FUNCTION_NAME}"
+          python scripts/restore_service.py
 
-      - name: Configure queues, deduplication, monitoring, alerts, and webhook security
+      - name: Prepare queues, state, monitoring, alerts, and authenticated webhook
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
@@ -167,9 +180,17 @@ jobs:
           STATUS_CHANNEL_URL: ${{ secrets.STATUS_CHANNEL_URL }}
           STATUS_BOT_TOKEN: ${{ secrets.STATUS_BOT_TOKEN }}
           MONTHLY_BUDGET_USD: ${{ vars.MONTHLY_BUDGET_USD || '1' }}
+        run: python scripts/configure_aws.py
+
+      - name: Deploy durable bot code after dependencies are ready
+        env:
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
         run: |
-          python -m pip install --upgrade boto3
-          python scripts/configure_aws.py
+          aws lambda update-function-code \
+            --function-name "${LAMBDA_FUNCTION_NAME}" \
+            --zip-file fileb://package.zip
+          aws lambda wait function-updated-v2 \
+            --function-name "${LAMBDA_FUNCTION_NAME}"
 
       - name: Run immediate external health check
         run: |
@@ -187,3 +208,23 @@ jobs:
           if not result.get("endpoint_ok") or not result.get("webhook_ok"):
               raise SystemExit(f"Post-deployment endpoint/webhook check failed: {result}")
           PY
+
+      - name: Remove legacy API Gateway route after smoke test
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+        run: python scripts/finalize_cutover.py
+
+      - name: Roll back to authenticated known-good service on any deployment failure
+        if: ${{ failure() && hashFiles('legacy-package.zip') != '' }}
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+        run: |
+          echo "::warning title=Production rollback::Restoring the last known-good synchronous Lambda after a failed migration."
+          aws lambda update-function-code \
+            --function-name "${LAMBDA_FUNCTION_NAME}" \
+            --zip-file fileb://legacy-package.zip
+          aws lambda wait function-updated-v2 \
+            --function-name "${LAMBDA_FUNCTION_NAME}"
+          python scripts/restore_service.py

--- a/scripts/configure_aws.py
+++ b/scripts/configure_aws.py
@@ -2,6 +2,7 @@ import json
 import os
 import secrets
 from pathlib import Path
+from typing import Callable, TypeVar
 
 from aws_setup.common import (
     DLQ_NAME,
@@ -19,7 +20,6 @@ from aws_setup.iam_runtime import (
     put_scheduler_policy,
 )
 from aws_setup.lambda_resources import (
-    disable_legacy_api_gateway_invocation,
     ensure_event_source,
     ensure_function_url,
     ensure_monitor_function,
@@ -34,6 +34,26 @@ from aws_setup.monitoring import (
 )
 from aws_setup.storage import ensure_queues, ensure_table, ensure_topic
 from aws_setup.telegram_setup import configure_webhook
+
+T = TypeVar("T")
+
+
+def run_stage(name: str, operation: Callable[..., T], *args, **kwargs) -> T:
+    """Run one idempotent provisioning stage with actionable Actions output."""
+    print(f"::group::{name}")
+    try:
+        result = operation(*args, **kwargs)
+        print(f"Completed: {name}")
+        return result
+    except Exception as error:
+        message = str(error).replace("\r", " ").replace("\n", " ")
+        print(
+            f"::error title=AWS provisioning failed at {name}::"
+            f"{type(error).__name__}: {message}"
+        )
+        raise
+    finally:
+        print("::endgroup::")
 
 
 def main() -> None:
@@ -55,16 +75,40 @@ def main() -> None:
     cloudwatch = client("cloudwatch", region)
     logs = client("logs", region)
 
-    account_id = sts.get_caller_identity()["Account"]
+    account_id = run_stage(
+        "Read AWS deployment identity",
+        lambda: sts.get_caller_identity()["Account"],
+    )
     alert_email = os.getenv("ALERT_EMAIL", "").strip()
     budget_amount = os.getenv("MONTHLY_BUDGET_USD", "1").strip() or "1"
 
-    queues = ensure_queues(sqs)
-    table_arn = ensure_table(dynamodb, region, account_id)
-    topic_arn = ensure_topic(sns, alert_email)
-
-    function_url = ensure_function_url(lambda_client, function_name)
-    current = lambda_client.get_function_configuration(FunctionName=function_name)
+    # Prepare every dependency before changing the public Lambda or Telegram
+    # webhook. A failure in this section leaves the last working bot untouched.
+    queues = run_stage("Create or update SQS queues", ensure_queues, sqs)
+    table_arn = run_stage(
+        "Create or update DynamoDB state table",
+        ensure_table,
+        dynamodb,
+        region,
+        account_id,
+    )
+    topic_arn = run_stage(
+        "Create or update SNS alert topic",
+        ensure_topic,
+        sns,
+        alert_email,
+    )
+    function_url = run_stage(
+        "Create or update Lambda Function URL",
+        ensure_function_url,
+        lambda_client,
+        function_name,
+    )
+    current = run_stage(
+        "Read current Lambda configuration",
+        lambda_client.get_function_configuration,
+        FunctionName=function_name,
+    )
     current_environment = current.get("Environment", {}).get("Variables", {})
     token = current_environment.get("TELEGRAM_BOT_TOKEN") or current_environment.get(
         "YOUR_TELEGRAM_BOT_TOKEN"
@@ -98,7 +142,9 @@ def main() -> None:
     }
 
     main_role_name = role_name_from_arn(current["Role"])
-    put_main_execution_policy(
+    run_stage(
+        "Grant main and worker runtime permissions",
+        put_main_execution_policy,
         iam,
         main_role_name,
         queues["queue_arn"],
@@ -106,15 +152,18 @@ def main() -> None:
         table_arn,
         topic_arn,
     )
-    main_config = update_main_function(lambda_client, function_name, shared_environment)
-    worker_arn = ensure_worker_function(
+    worker_arn = run_stage(
+        "Create or update SQS worker Lambda",
+        ensure_worker_function,
         lambda_client,
         bot_zip,
-        main_config["Role"],
+        current["Role"],
         shared_environment,
     )
 
-    monitor_role_arn = put_monitor_policy(
+    monitor_role_arn = run_stage(
+        "Create or update monitor IAM role",
+        put_monitor_policy,
         iam,
         queues["queue_arn"],
         queues["dlq_arn"],
@@ -123,22 +172,74 @@ def main() -> None:
         account_id,
         region,
     )
-    monitor_arn = ensure_monitor_function(
+    monitor_arn = run_stage(
+        "Create or update monitor Lambda",
+        ensure_monitor_function,
         lambda_client,
         monitor_zip,
         monitor_role_arn,
         shared_environment,
     )
 
-    ensure_event_source(lambda_client, worker_arn, queues["queue_arn"])
-    scheduler_role_arn = put_scheduler_policy(iam, monitor_arn)
-    ensure_schedule(scheduler, monitor_arn, scheduler_role_arn)
-    ensure_alarms(cloudwatch, function_name, topic_arn)
-    ensure_log_retention(logs, [function_name, WORKER_FUNCTION, MONITOR_FUNCTION])
-    ensure_budget(account_id, alert_email, budget_amount)
+    run_stage(
+        "Connect SQS queue to worker Lambda",
+        ensure_event_source,
+        lambda_client,
+        worker_arn,
+        queues["queue_arn"],
+    )
+    scheduler_role_arn = run_stage(
+        "Create or update scheduler IAM role",
+        put_scheduler_policy,
+        iam,
+        monitor_arn,
+    )
+    run_stage(
+        "Create or update 15-minute health schedule",
+        ensure_schedule,
+        scheduler,
+        monitor_arn,
+        scheduler_role_arn,
+    )
+    run_stage(
+        "Create or update CloudWatch alarms",
+        ensure_alarms,
+        cloudwatch,
+        function_name,
+        topic_arn,
+    )
+    run_stage(
+        "Set CloudWatch log retention",
+        ensure_log_retention,
+        logs,
+        [function_name, WORKER_FUNCTION, MONITOR_FUNCTION],
+    )
+    run_stage(
+        "Create or update AWS budget",
+        ensure_budget,
+        account_id,
+        alert_email,
+        budget_amount,
+    )
 
-    webhook_info = configure_webhook(token, function_url, webhook_secret)
-    disable_legacy_api_gateway_invocation(lambda_client, function_name)
+    # Cut over only after every dependency is ready. The currently deployed
+    # handler already understands Telegram's secret header, so the old code
+    # remains operational while the workflow uploads the new package next.
+    run_stage(
+        "Configure public Lambda environment",
+        update_main_function,
+        lambda_client,
+        function_name,
+        shared_environment,
+    )
+    webhook_info = run_stage(
+        "Register authenticated Telegram Function URL webhook",
+        configure_webhook,
+        token,
+        function_url,
+        webhook_secret,
+    )
+
     print(
         json.dumps(
             {
@@ -153,6 +254,7 @@ def main() -> None:
                 "alert_email_configured": bool(alert_email),
                 "status_channel_configured": bool(optional_runtime_values["STATUS_CHANNEL_ID"]),
                 "monthly_budget_usd": budget_amount if alert_email else None,
+                "legacy_api_gateway_preserved_until_smoke_test": True,
             },
             indent=2,
         )

--- a/scripts/finalize_cutover.py
+++ b/scripts/finalize_cutover.py
@@ -1,0 +1,16 @@
+import os
+
+from aws_setup.common import client
+from aws_setup.lambda_resources import disable_legacy_api_gateway_invocation
+
+
+def main() -> None:
+    region = os.environ["AWS_REGION"]
+    function_name = os.getenv("LAMBDA_FUNCTION_NAME", "ToEnWikipediaBot")
+    lambda_client = client("lambda", region)
+    disable_legacy_api_gateway_invocation(lambda_client, function_name)
+    print("Legacy API Gateway invocation permission removed after successful smoke test.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/restore_service.py
+++ b/scripts/restore_service.py
@@ -1,0 +1,42 @@
+import os
+import secrets
+
+from aws_setup.common import client
+from aws_setup.lambda_resources import ensure_function_url, update_main_function
+from aws_setup.telegram_setup import configure_webhook
+
+
+def main() -> None:
+    """Restore the known-good synchronous handler with an authenticated webhook."""
+    region = os.environ["AWS_REGION"]
+    function_name = os.getenv("LAMBDA_FUNCTION_NAME", "ToEnWikipediaBot")
+    lambda_client = client("lambda", region)
+
+    current = lambda_client.get_function_configuration(FunctionName=function_name)
+    environment = current.get("Environment", {}).get("Variables", {})
+    token = environment.get("TELEGRAM_BOT_TOKEN") or environment.get(
+        "YOUR_TELEGRAM_BOT_TOKEN"
+    )
+    if not token:
+        raise RuntimeError("The Lambda function has no Telegram bot token environment variable")
+
+    function_url = ensure_function_url(lambda_client, function_name)
+    webhook_secret = environment.get("TELEGRAM_WEBHOOK_SECRET") or secrets.token_urlsafe(32)
+    update_main_function(
+        lambda_client,
+        function_name,
+        {
+            "TELEGRAM_BOT_TOKEN": token,
+            "TELEGRAM_WEBHOOK_SECRET": webhook_secret,
+            "FUNCTION_URL": function_url,
+        },
+    )
+    webhook_info = configure_webhook(token, function_url, webhook_secret)
+    print(
+        "Known-good synchronous bot restored at the authenticated Function URL; "
+        f"pending updates: {webhook_info.get('pending_update_count', 0)}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The previous production workflow uploaded the new public Lambda before SQS, DynamoDB, IAM, monitoring, and webhook provisioning had succeeded. When provisioning failed, the bot could be left on code that expected infrastructure that did not exist.

This patch makes the deployment fail-safe:

- restores the last confirmed working handler at the authenticated Lambda Function URL before migration;
- builds a dedicated rollback package from commit `28dd94002753075a9fab0f5bd7f3d342a84e04d8`;
- provisions every queue, table, policy, worker, monitor, schedule, alarm, log-retention rule, and budget before deploying the new public handler;
- prints an exact GitHub Actions annotation naming the failing AWS stage and exception;
- updates the public Lambda environment and Telegram secret-bound webhook only after dependencies are ready;
- deploys the durable handler after the authenticated webhook is already usable by the known-good handler;
- runs the independent external smoke test;
- removes the legacy API Gateway route only after that smoke test succeeds;
- automatically redeploys the authenticated known-good package and repairs the webhook after any migration or smoke-test failure.

This intentionally does not merge the temporary unsigned-webhook compatibility branch; authentication remains enforced during both forward deployment and rollback.