### PR TITLE
Minimize authenticated service restoration before AWS migration

### DIFF
--- a/scripts/restore_service.py
+++ b/scripts/restore_service.py
@@ -1,9 +1,28 @@
 import os
 import secrets
+from typing import Callable, TypeVar
 
 from aws_setup.common import client
-from aws_setup.lambda_resources import ensure_function_url, update_main_function
 from aws_setup.telegram_setup import configure_webhook
+
+T = TypeVar("T")
+
+
+def run_stage(name: str, operation: Callable[..., T], *args, **kwargs) -> T:
+    print(f"::group::{name}")
+    try:
+        result = operation(*args, **kwargs)
+        print(f"Completed: {name}")
+        return result
+    except Exception as error:
+        message = str(error).replace("\r", " ").replace("\n", " ")
+        print(
+            f"::error title=Service restoration failed at {name}::"
+            f"{type(error).__name__}: {message}"
+        )
+        raise
+    finally:
+        print("::endgroup::")
 
 
 def main() -> None:
@@ -12,26 +31,57 @@ def main() -> None:
     function_name = os.getenv("LAMBDA_FUNCTION_NAME", "ToEnWikipediaBot")
     lambda_client = client("lambda", region)
 
-    current = lambda_client.get_function_configuration(FunctionName=function_name)
-    environment = current.get("Environment", {}).get("Variables", {})
+    current = run_stage(
+        "Read current Lambda configuration",
+        lambda_client.get_function_configuration,
+        FunctionName=function_name,
+    )
+    environment = dict(current.get("Environment", {}).get("Variables", {}))
     token = environment.get("TELEGRAM_BOT_TOKEN") or environment.get(
         "YOUR_TELEGRAM_BOT_TOKEN"
     )
     if not token:
         raise RuntimeError("The Lambda function has no Telegram bot token environment variable")
 
-    function_url = ensure_function_url(lambda_client, function_name)
+    def read_function_url() -> str:
+        try:
+            return lambda_client.get_function_url_config(FunctionName=function_name)[
+                "FunctionUrl"
+            ]
+        except Exception:
+            existing = environment.get("FUNCTION_URL")
+            if existing:
+                return existing
+            raise
+
+    function_url = run_stage("Read existing Lambda Function URL", read_function_url)
     webhook_secret = environment.get("TELEGRAM_WEBHOOK_SECRET") or secrets.token_urlsafe(32)
-    update_main_function(
-        lambda_client,
-        function_name,
+    environment.update(
         {
             "TELEGRAM_BOT_TOKEN": token,
             "TELEGRAM_WEBHOOK_SECRET": webhook_secret,
             "FUNCTION_URL": function_url,
-        },
+        }
     )
-    webhook_info = configure_webhook(token, function_url, webhook_secret)
+
+    run_stage(
+        "Set only the webhook restoration environment",
+        lambda_client.update_function_configuration,
+        FunctionName=function_name,
+        Environment={"Variables": environment},
+    )
+    run_stage(
+        "Wait for Lambda restoration configuration",
+        lambda_client.get_waiter("function_updated_v2").wait,
+        FunctionName=function_name,
+    )
+    webhook_info = run_stage(
+        "Register authenticated Telegram webhook",
+        configure_webhook,
+        token,
+        function_url,
+        webhook_secret,
+    )
     print(
         "Known-good synchronous bot restored at the authenticated Function URL; "
         f"pending updates: {webhook_info.get('pending_update_count', 0)}"

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -9,6 +10,7 @@ SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import bootstrap_oidc
+import restore_service
 from aws_setup import monitoring, storage, telegram_setup
 
 
@@ -65,6 +67,65 @@ class TelegramProvisioningTests(unittest.TestCase):
         self.assertEqual(
             webhook["allowed_updates"],
             ["message", "channel_post", "inline_query"],
+        )
+
+
+class ServiceRestorationTests(unittest.TestCase):
+    def test_restore_updates_only_environment_and_registers_secret_webhook(self):
+        lambda_client = Mock()
+        lambda_client.get_function_configuration.return_value = {
+            "Environment": {
+                "Variables": {
+                    "TELEGRAM_BOT_TOKEN": "token",
+                    "EXISTING_VALUE": "preserved",
+                }
+            }
+        }
+        lambda_client.get_function_url_config.return_value = {
+            "FunctionUrl": "https://example.lambda-url.aws/"
+        }
+        waiter = Mock()
+        lambda_client.get_waiter.return_value = waiter
+
+        with patch.dict(
+            os.environ,
+            {
+                "AWS_REGION": "eu-north-1",
+                "LAMBDA_FUNCTION_NAME": "ToEnWikipediaBot",
+            },
+            clear=False,
+        ), patch.object(
+            restore_service,
+            "client",
+            return_value=lambda_client,
+        ), patch.object(
+            restore_service,
+            "configure_webhook",
+            return_value={"pending_update_count": 0},
+        ) as configure_webhook, patch.object(
+            restore_service.secrets,
+            "token_urlsafe",
+            return_value="generated-secret",
+        ):
+            restore_service.main()
+
+        update = lambda_client.update_function_configuration.call_args.kwargs
+        self.assertEqual(update["FunctionName"], "ToEnWikipediaBot")
+        variables = update["Environment"]["Variables"]
+        self.assertEqual(variables["EXISTING_VALUE"], "preserved")
+        self.assertEqual(variables["TELEGRAM_WEBHOOK_SECRET"], "generated-secret")
+        self.assertEqual(
+            variables["FUNCTION_URL"],
+            "https://example.lambda-url.aws/",
+        )
+        self.assertNotIn("Runtime", update)
+        self.assertNotIn("MemorySize", update)
+        self.assertNotIn("Timeout", update)
+        waiter.wait.assert_called_once_with(FunctionName="ToEnWikipediaBot")
+        configure_webhook.assert_called_once_with(
+            "token",
+            "https://example.lambda-url.aws/",
+            "generated-secret",
         )
 
 


### PR DESCRIPTION
The atomic deployment correctly stopped before provisioning, but the restoration helper itself failed. Its original implementation performed broader Function URL creation, Lambda runtime reconfiguration, and concurrency changes than are necessary for restoring service.

This patch narrows the recovery boundary to four operations:

1. read the existing Lambda configuration;
2. read the already-existing Function URL;
3. update only the merged environment variables needed for the token, webhook secret, and Function URL;
4. register and verify Telegram's secret-bound webhook.

Each operation now emits an exact GitHub Actions annotation on failure. A focused regression test verifies that existing environment values are preserved, no runtime/memory/timeout fields are changed, a generated secret is installed, the Lambda waiter runs, and Telegram receives the same secret and Function URL.