### PR TITLE
Migrate all Lambda functions to ARM64 with canary validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   PYTHON_VERSION: "3.13"
+  LAMBDA_ARCHITECTURE: arm64
+  PIP_LAMBDA_PLATFORM: manylinux2014_aarch64
   AWS_DEPLOY_ROLE_ARN: arn:aws:iam::590183760311:role/GitHubActions-ToEnWikipediaBot
   AWS_RETRY_MODE: standard
   AWS_MAX_ATTEMPTS: "10"
@@ -42,6 +44,18 @@ jobs:
         run: |
           python -m compileall -q ToEnWikipediaBot.py monitor.py scripts tests
           python -m unittest discover -s tests -v
+
+      - name: Build and verify the ARM64 Lambda dependencies
+        run: |
+          rm -rf arm-package-test
+          python -m pip install \
+            --platform "${PIP_LAMBDA_PLATFORM}" \
+            --implementation cp \
+            --python-version "${PYTHON_VERSION}" \
+            --only-binary=:all: \
+            --target arm-package-test \
+            -r requirements.txt
+          python scripts/verify_lambda_package.py arm-package-test "${LAMBDA_ARCHITECTURE}"
 
   dependency-review:
     name: Review dependency changes
@@ -96,7 +110,7 @@ jobs:
           mask-aws-account-id: true
           unset-current-credentials: true
 
-      - name: Attempt non-blocking GitHub OIDC bootstrap
+      - name: Attempt GitHub OIDC bootstrap
         id: bootstrap
         if: steps.oidc.outcome == 'failure'
         continue-on-error: true
@@ -106,6 +120,12 @@ jobs:
         run: |
           python -m pip install --upgrade boto3
           python scripts/bootstrap_oidc_v2.py
+
+      - name: Stop safely when bootstrap permissions are missing
+        if: steps.oidc.outcome == 'failure' && steps.bootstrap.outcome == 'failure'
+        run: |
+          echo "::error title=One-time AWS IAM bootstrap required::No production resource was changed. Attach aws/github-deployer-oidc-bootstrap-policy.json to the GitHub_Deployer IAM user with an administrator session, then re-run this workflow."
+          exit 1
 
       - name: Switch to short-lived OIDC credentials when bootstrap succeeds
         if: steps.oidc.outcome == 'failure' && steps.bootstrap.outcome == 'success'
@@ -117,9 +137,8 @@ jobs:
           mask-aws-account-id: true
           unset-current-credentials: true
 
-      - name: Refresh OIDC policy without blocking production
+      - name: Refresh repository-scoped OIDC policy
         if: steps.oidc.outcome == 'success' || steps.bootstrap.outcome == 'success'
-        continue-on-error: true
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
@@ -128,46 +147,67 @@ jobs:
           python scripts/bootstrap_oidc_v2.py
 
       - name: Record credential migration status
-        run: |
-          if [ "${{ steps.oidc.outcome }}" = "success" ] || [ "${{ steps.bootstrap.outcome }}" = "success" ]; then
-            echo "AWS deployment is using short-lived GitHub OIDC credentials."
-          else
-            echo "::warning title=GitHub OIDC migration deferred::Deployment is continuing with the existing AWS secrets. Reliability and monitoring rollout is not blocked; IAM/OIDC can be completed separately."
-          fi
+        run: echo "AWS deployment is using short-lived repository-scoped GitHub OIDC credentials."
 
-      - name: Build new, monitor, and rollback Lambda packages
+      - name: Build ARM64 bot, monitor, and architecture-aware rollback packages
         run: |
           python -m pip install --upgrade pip boto3
-          rm -rf package monitor-package legacy-package
-          mkdir -p package monitor-package
-          python -m pip install --only-binary=:all: -r requirements.txt -t package
-          cp ToEnWikipediaBot.py package/
-          (cd package && zip -q -r ../package.zip .)
+          rm -rf package-arm64 monitor-package legacy-arm64-package legacy-x86-package
+          mkdir -p package-arm64 monitor-package legacy-x86-package
+
+          python -m pip install \
+            --platform "${PIP_LAMBDA_PLATFORM}" \
+            --implementation cp \
+            --python-version "${PYTHON_VERSION}" \
+            --only-binary=:all: \
+            --target package-arm64 \
+            -r requirements.txt
+          cp ToEnWikipediaBot.py package-arm64/
+          python scripts/verify_lambda_package.py package-arm64 "${LAMBDA_ARCHITECTURE}"
+          (cd package-arm64 && zip -q -r ../package-arm64.zip .)
+
+          cp -a package-arm64 legacy-arm64-package
+          git show "${LAST_KNOWN_GOOD_COMMIT}:ToEnWikipediaBot.py" > legacy-arm64-package/ToEnWikipediaBot.py
+          python scripts/verify_lambda_package.py legacy-arm64-package "${LAMBDA_ARCHITECTURE}"
+          (cd legacy-arm64-package && zip -q -r ../legacy-arm64-package.zip .)
+
+          python -m pip install --only-binary=:all: -r requirements.txt -t legacy-x86-package
+          git show "${LAST_KNOWN_GOOD_COMMIT}:ToEnWikipediaBot.py" > legacy-x86-package/ToEnWikipediaBot.py
+          (cd legacy-x86-package && zip -q -r ../legacy-x86-package.zip .)
 
           cp monitor.py monitor-package/
           (cd monitor-package && zip -q -r ../monitor-package.zip .)
-
-          cp -a package legacy-package
-          git show "${LAST_KNOWN_GOOD_COMMIT}:ToEnWikipediaBot.py" > legacy-package/ToEnWikipediaBot.py
-          (cd legacy-package && zip -q -r ../legacy-package.zip .)
 
       - name: Restore authenticated known-good service before migration
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
         run: |
+          CURRENT_ARCHITECTURE="$(aws lambda get-function-configuration --function-name "${LAMBDA_FUNCTION_NAME}" --query 'Architectures[0]' --output text)"
+          if [ "${CURRENT_ARCHITECTURE}" = "arm64" ]; then
+            ROLLBACK_PACKAGE=legacy-arm64-package.zip
+          else
+            ROLLBACK_PACKAGE=legacy-x86-package.zip
+          fi
           aws lambda update-function-code \
             --function-name "${LAMBDA_FUNCTION_NAME}" \
-            --zip-file fileb://legacy-package.zip
+            --zip-file "fileb://${ROLLBACK_PACKAGE}"
           aws lambda wait function-updated-v2 \
             --function-name "${LAMBDA_FUNCTION_NAME}"
           python scripts/restore_service.py
+
+      - name: Validate ARM64 on the worker and migrate the live Lambda
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+          BOT_ZIP_PATH: package-arm64.zip
+        run: python scripts/deploy_arm64.py
 
       - name: Prepare queues, state, monitoring, alerts, and authenticated webhook
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
-          BOT_ZIP_PATH: package.zip
+          BOT_ZIP_PATH: package-arm64.zip
           MONITOR_ZIP_PATH: monitor-package.zip
           GITHUB_SHA: ${{ github.sha }}
           ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
@@ -177,16 +217,6 @@ jobs:
           STATUS_BOT_TOKEN: ${{ secrets.STATUS_BOT_TOKEN }}
           MONTHLY_BUDGET_USD: ${{ vars.MONTHLY_BUDGET_USD || '1' }}
         run: python scripts/configure_aws.py
-
-      - name: Deploy durable bot code after dependencies are ready
-        env:
-          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
-        run: |
-          aws lambda update-function-code \
-            --function-name "${LAMBDA_FUNCTION_NAME}" \
-            --zip-file fileb://package.zip
-          aws lambda wait function-updated-v2 \
-            --function-name "${LAMBDA_FUNCTION_NAME}"
 
       - name: Run immediate external health check
         run: |
@@ -222,16 +252,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Roll back to authenticated known-good service on any deployment failure
-        if: ${{ failure() && hashFiles('legacy-package.zip') != '' }}
+      - name: Roll back to an architecture-compatible known-good service
+        if: ${{ failure() && hashFiles('legacy-x86-package.zip') != '' }}
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
         run: |
-          echo "::warning title=Production rollback::Restoring the last known-good synchronous Lambda after a failed migration."
+          echo "::warning title=Production rollback::Restoring the last known-good synchronous Lambda with dependencies matching its current architecture."
+          CURRENT_ARCHITECTURE="$(aws lambda get-function-configuration --function-name "${LAMBDA_FUNCTION_NAME}" --query 'Architectures[0]' --output text)"
+          if [ "${CURRENT_ARCHITECTURE}" = "arm64" ]; then
+            ROLLBACK_PACKAGE=legacy-arm64-package.zip
+          else
+            ROLLBACK_PACKAGE=legacy-x86-package.zip
+          fi
           aws lambda update-function-code \
             --function-name "${LAMBDA_FUNCTION_NAME}" \
-            --zip-file fileb://legacy-package.zip
+            --zip-file "fileb://${ROLLBACK_PACKAGE}"
           aws lambda wait function-updated-v2 \
             --function-name "${LAMBDA_FUNCTION_NAME}"
           python scripts/restore_service.py

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Telegram may redeliver webhook updates, and SQS/Lambda processing is at-least-on
 
 - required Telegram webhook secret;
 - POST-only webhook with JSON validation and a 64 KiB request limit;
-- strict Wikipedia-domain validation;
+- strict structural Wikipedia-domain validation;
 - five links maximum per update;
 - distributed limits of 10 conversion requests per user and 30 per chat per minute;
 - separate distributed limits for commands and inline requests;
 - rate-limit warnings deduplicated per chat;
 - dedicated webhook and worker Lambda concurrency limits;
 - SQS dead-letter handling and bounded retry behavior;
-- short-lived GitHub OIDC deployment credentials;
+- short-lived repository-scoped GitHub OIDC deployment credentials;
 - 14-day CloudWatch log retention;
 - up to seven CloudWatch alarms and an optional AWS Budget, while keeping the account at or below ten standard alarms.
 
@@ -58,9 +58,9 @@ Telegram may redeliver webhook updates, and SQS/Lambda processing is at-least-on
 
 The deployment intentionally uses small, serverless resources:
 
-- one 256 MB webhook Lambda with three reserved concurrent executions;
-- one 256 MB SQS worker Lambda with two reserved concurrent executions;
-- one 128 MB monitor Lambda invoked every 15 minutes;
+- one 256 MB ARM64 webhook Lambda with three reserved concurrent executions;
+- one 256 MB ARM64 SQS worker Lambda with two reserved concurrent executions;
+- one 128 MB ARM64 monitor Lambda invoked every 15 minutes;
 - one standard SQS queue and one dead-letter queue;
 - one DynamoDB table provisioned at 10 read and 10 write capacity units;
 - one EventBridge Scheduler schedule;
@@ -68,11 +68,11 @@ The deployment intentionally uses small, serverless resources:
 - up to seven CloudWatch alarms, automatically capped so the account stays at or below ten standard alarms;
 - 14-day log retention.
 
-Separating the SQS worker preserves webhook capacity during recovery and avoids configuring SQS maximum concurrency, allowing Lambda to reduce idle queue polling. This is designed to remain within the traditional AWS free allowances at normal small-bot traffic, but AWS pricing and account eligibility can vary. Set `ALERT_EMAIL` and the deployment will also create a small monthly budget alert when the account has a free budget slot.
+Separating the SQS worker preserves webhook capacity during recovery and avoids configuring SQS maximum concurrency, allowing Lambda to reduce idle queue polling. ARM64 uses AWS Graviton and is selected for efficiency. The footprint is designed to remain inside the normal free allowances for a small bot, but AWS pricing and account eligibility can vary. Set `ALERT_EMAIL` and the deployment will also create a small monthly budget alert when the account has a free budget slot.
 
 ## Deployment
 
-The GitHub Actions workflow tests every pull request and every `main` deployment under Python 3.13, matching the Lambda runtime.
+The GitHub Actions workflow tests every pull request and every `main` deployment under Python 3.13, matching the Lambda runtime. It cross-installs `manylinux2014_aarch64` wheels, inspects every native ELF extension, invokes the exact package on the ARM64 worker as a canary, and only then migrates the public webhook Lambda.
 
 Required existing GitHub secrets:
 
@@ -93,18 +93,26 @@ Optional GitHub repository variable:
 
 - `MONTHLY_BUDGET_USD` — defaults to `1`.
 
-On the first successful deployment, the workflow creates a repository- and branch-restricted GitHub OIDC role. After that run succeeds, delete the long-lived `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` GitHub secrets; future deployments use short-lived credentials.
+### One-time AWS OIDC bootstrap
+
+The long-lived IAM user only needs permission to create the repository-scoped GitHub OIDC provider and role. Using an AWS administrator session, attach the repository file `aws/github-deployer-oidc-bootstrap-policy.json` as an inline policy on the `GitHub_Deployer` user, then re-run the workflow.
+
+The workflow stops before changing Lambda when this bootstrap permission is missing. On the first successful deployment it creates a role restricted to this repository and the `main` branch. After that run succeeds, delete the long-lived `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` GitHub secrets; future deployments use short-lived credentials.
 
 The deployment automatically:
 
-1. deploys the code;
-2. creates or updates SQS, DynamoDB, SNS, IAM, the dedicated worker and monitor Lambdas, schedule, alarms, log retention, and optional budget;
-3. creates and stores a webhook secret without printing it;
-4. points Telegram directly to the Lambda Function URL with `drop_pending_updates=false`;
-5. limits Telegram to `message`, `channel_post`, and `inline_query` updates;
-6. configures the BotFather command menu through `setMyCommands`;
-7. removes legacy API Gateway invoke permission after the Function URL webhook is verified;
-8. invokes the independent monitor and fails deployment only when the Function URL or Telegram webhook is not working; an existing queue backlog remains visible without blocking a repair deployment.
+1. verifies the Python tests, dependency review, and ARM64 native wheels;
+2. restores an architecture-compatible known-good bot before migration;
+3. validates the ARM64 package through a real worker Lambda invocation;
+4. migrates the public Lambda to ARM64 and deploys the durable handler;
+5. creates or updates SQS, DynamoDB, SNS, IAM, the dedicated worker and monitor Lambdas, schedule, alarms, log retention, and optional budget;
+6. creates and stores a webhook secret without printing it;
+7. points Telegram directly to the Lambda Function URL with `drop_pending_updates=false`;
+8. limits Telegram to `message`, `channel_post`, and `inline_query` updates;
+9. configures the BotFather command menu through `setMyCommands`;
+10. invokes the independent monitor and removes legacy API Gateway invoke permission only after the Function URL webhook is verified.
+
+If deployment fails after packages are built, the workflow reads the function's current architecture and restores either the ARM64 or x86_64 known-good package automatically.
 
 The old API Gateway resource may remain visible in AWS after its invoke permission is removed. It can be deleted manually once the Function URL webhook has been verified.
 

--- a/aws/github-deployer-oidc-bootstrap-policy.json
+++ b/aws/github-deployer-oidc-bootstrap-policy.json
@@ -1,0 +1,41 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadDeploymentIdentityAndLambdaRole",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "lambda:GetFunctionConfiguration"
+      ],
+      "Resource": [
+        "*",
+        "arn:aws:lambda:eu-north-1:590183760311:function:ToEnWikipediaBot"
+      ]
+    },
+    {
+      "Sid": "BootstrapGitHubActionsOidcProvider",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetOpenIDConnectProvider",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:AddClientIDToOpenIDConnectProvider",
+        "iam:UpdateOpenIDConnectProviderThumbprint",
+        "iam:TagOpenIDConnectProvider"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "BootstrapRepositoryScopedDeploymentRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:TagRole"
+      ],
+      "Resource": "arn:aws:iam::590183760311:role/GitHubActions-ToEnWikipediaBot"
+    }
+  ]
+}

--- a/scripts/aws_setup/lambda_resources.py
+++ b/scripts/aws_setup/lambda_resources.py
@@ -6,6 +6,8 @@ from botocore.exceptions import ClientError
 
 from aws_setup.common import APPLICATION, MONITOR_FUNCTION, WORKER_FUNCTION
 
+LAMBDA_ARCHITECTURE = "arm64"
+
 
 def ensure_function_url(lambda_client, function_name: str) -> str:
     try:
@@ -79,12 +81,27 @@ def disable_legacy_api_gateway_invocation(lambda_client, function_name: str) -> 
                 raise
 
 
+def _ensure_function_architecture(lambda_client, function_name: str) -> dict:
+    current = lambda_client.get_function_configuration(FunctionName=function_name)
+    architectures = current.get("Architectures") or ["x86_64"]
+    if architectures != [LAMBDA_ARCHITECTURE]:
+        lambda_client.update_function_configuration(
+            FunctionName=function_name,
+            Architectures=[LAMBDA_ARCHITECTURE],
+        )
+        lambda_client.get_waiter("function_updated_v2").wait(
+            FunctionName=function_name
+        )
+        current = lambda_client.get_function_configuration(FunctionName=function_name)
+    return current
+
+
 def update_main_function(
     lambda_client,
     function_name: str,
     environment: dict[str, str],
 ) -> dict:
-    current = lambda_client.get_function_configuration(FunctionName=function_name)
+    current = _ensure_function_architecture(lambda_client, function_name)
     merged = dict(current.get("Environment", {}).get("Variables", {}))
     merged.update({key: value for key, value in environment.items() if value != ""})
     lambda_client.update_function_configuration(
@@ -111,7 +128,7 @@ def ensure_worker_function(
 ) -> str:
     code = bot_zip.read_bytes()
     try:
-        current = lambda_client.get_function_configuration(FunctionName=WORKER_FUNCTION)
+        current = _ensure_function_architecture(lambda_client, WORKER_FUNCTION)
         lambda_client.update_function_code(
             FunctionName=WORKER_FUNCTION,
             ZipFile=code,
@@ -144,7 +161,7 @@ def ensure_worker_function(
             Publish=False,
             Environment={"Variables": environment},
             Tags={"Application": APPLICATION},
-            Architectures=["x86_64"],
+            Architectures=[LAMBDA_ARCHITECTURE],
         )
 
     lambda_client.get_waiter("function_updated_v2").wait(FunctionName=WORKER_FUNCTION)
@@ -165,7 +182,7 @@ def ensure_monitor_function(
 ) -> str:
     code = monitor_zip.read_bytes()
     try:
-        current = lambda_client.get_function_configuration(FunctionName=MONITOR_FUNCTION)
+        current = _ensure_function_architecture(lambda_client, MONITOR_FUNCTION)
         lambda_client.update_function_code(
             FunctionName=MONITOR_FUNCTION,
             ZipFile=code,
@@ -200,12 +217,13 @@ def ensure_monitor_function(
                     Publish=False,
                     Environment={"Variables": environment},
                     Tags={"Application": APPLICATION},
-                    Architectures=["x86_64"],
+                    Architectures=[LAMBDA_ARCHITECTURE],
                 )
                 break
             except ClientError as create_error:
                 if (
-                    create_error.response["Error"]["Code"] != "InvalidParameterValueException"
+                    create_error.response["Error"]["Code"]
+                    != "InvalidParameterValueException"
                     or attempt == 5
                 ):
                     raise

--- a/scripts/deploy_arm64.py
+++ b/scripts/deploy_arm64.py
@@ -1,0 +1,141 @@
+import json
+import os
+from pathlib import Path
+
+import boto3
+from botocore.exceptions import ClientError
+
+MAIN_ARCHITECTURE = "arm64"
+WORKER_FUNCTION = "ToEnWikipediaBotWorker"
+HEALTH_EVENT = {
+    "requestContext": {"http": {"method": "GET"}},
+    "rawPath": "/health",
+}
+
+
+def error_code(error: ClientError) -> str:
+    return error.response.get("Error", {}).get("Code", "Unknown")
+
+
+def wait_for_update(lambda_client, function_name: str) -> None:
+    lambda_client.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+
+
+def ensure_architecture(lambda_client, function_name: str) -> dict:
+    current = lambda_client.get_function_configuration(FunctionName=function_name)
+    if (current.get("Architectures") or ["x86_64"]) != [MAIN_ARCHITECTURE]:
+        lambda_client.update_function_configuration(
+            FunctionName=function_name,
+            Architectures=[MAIN_ARCHITECTURE],
+        )
+        wait_for_update(lambda_client, function_name)
+        current = lambda_client.get_function_configuration(FunctionName=function_name)
+    return current
+
+
+def update_code(lambda_client, function_name: str, code: bytes) -> None:
+    lambda_client.update_function_code(
+        FunctionName=function_name,
+        ZipFile=code,
+        Publish=False,
+    )
+    wait_for_update(lambda_client, function_name)
+
+
+def invoke_health(lambda_client, function_name: str) -> dict:
+    response = lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(HEALTH_EVENT).encode("utf-8"),
+    )
+    payload = json.loads(response["Payload"].read().decode("utf-8"))
+    if response.get("FunctionError"):
+        raise RuntimeError(f"{function_name} failed its ARM64 health invocation: {payload}")
+    if payload.get("statusCode") != 200:
+        raise RuntimeError(f"{function_name} returned an unhealthy response: {payload}")
+    body = json.loads(payload.get("body", "{}"))
+    if body.get("status") != "ok":
+        raise RuntimeError(f"{function_name} returned an invalid health body: {payload}")
+    return body
+
+
+def ensure_worker_canary(lambda_client, main_config: dict, code: bytes) -> None:
+    try:
+        current = ensure_architecture(lambda_client, WORKER_FUNCTION)
+        update_code(lambda_client, WORKER_FUNCTION, code)
+        merged_environment = dict(
+            current.get("Environment", {}).get("Variables", {})
+        )
+        merged_environment.update(
+            main_config.get("Environment", {}).get("Variables", {})
+        )
+        lambda_client.update_function_configuration(
+            FunctionName=WORKER_FUNCTION,
+            Runtime="python3.13",
+            Handler="ToEnWikipediaBot.lambda_handler",
+            Role=main_config["Role"],
+            MemorySize=256,
+            Timeout=15,
+            Environment={"Variables": merged_environment},
+        )
+        wait_for_update(lambda_client, WORKER_FUNCTION)
+    except ClientError as error:
+        if error_code(error) != "ResourceNotFoundException":
+            raise
+        lambda_client.create_function(
+            FunctionName=WORKER_FUNCTION,
+            Runtime="python3.13",
+            Role=main_config["Role"],
+            Handler="ToEnWikipediaBot.lambda_handler",
+            Code={"ZipFile": code},
+            Description="ARM64 canary and SQS worker for ToEnWikipediaBot",
+            Timeout=15,
+            MemorySize=256,
+            Publish=False,
+            Environment={
+                "Variables": main_config.get("Environment", {}).get("Variables", {})
+            },
+            Tags={"Application": "ToEnWikipediaBot"},
+            Architectures=[MAIN_ARCHITECTURE],
+        )
+        lambda_client.get_waiter("function_active_v2").wait(
+            FunctionName=WORKER_FUNCTION
+        )
+
+    invoke_health(lambda_client, WORKER_FUNCTION)
+
+
+def main() -> None:
+    region = os.environ["AWS_REGION"]
+    function_name = os.getenv("LAMBDA_FUNCTION_NAME", "ToEnWikipediaBot")
+    package = Path(os.getenv("BOT_ZIP_PATH", "package-arm64.zip"))
+    if not package.exists():
+        raise FileNotFoundError(package)
+
+    lambda_client = boto3.client("lambda", region_name=region)
+    code = package.read_bytes()
+    main_config = lambda_client.get_function_configuration(FunctionName=function_name)
+
+    # The worker is the canary: the exact ARM package must import and answer a
+    # real Lambda invocation before the public webhook function is migrated.
+    ensure_worker_canary(lambda_client, main_config, code)
+
+    ensure_architecture(lambda_client, function_name)
+    update_code(lambda_client, function_name, code)
+    health = invoke_health(lambda_client, function_name)
+
+    print(
+        json.dumps(
+            {
+                "architecture": MAIN_ARCHITECTURE,
+                "worker_canary": "healthy",
+                "main_function": function_name,
+                "main_health": health,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_lambda_package.py
+++ b/scripts/verify_lambda_package.py
@@ -1,0 +1,63 @@
+import argparse
+import struct
+from pathlib import Path
+
+ELF_MACHINE_NAMES = {
+    62: "x86_64",
+    183: "arm64",
+}
+EXPECTED_MACHINE = {
+    "x86_64": 62,
+    "arm64": 183,
+}
+
+
+def elf_machine(path: Path) -> int | None:
+    data = path.read_bytes()[:20]
+    if len(data) < 20 or data[:4] != b"\x7fELF":
+        return None
+    byte_order = data[5]
+    if byte_order == 1:
+        return struct.unpack("<H", data[18:20])[0]
+    if byte_order == 2:
+        return struct.unpack(">H", data[18:20])[0]
+    raise ValueError(f"Unknown ELF byte order in {path}")
+
+
+def verify_package(root: Path, architecture: str) -> list[Path]:
+    expected = EXPECTED_MACHINE[architecture]
+    native_files: list[Path] = []
+    mismatches: list[str] = []
+
+    for path in sorted(root.rglob("*.so")):
+        machine = elf_machine(path)
+        if machine is None:
+            continue
+        native_files.append(path)
+        if machine != expected:
+            actual = ELF_MACHINE_NAMES.get(machine, f"ELF machine {machine}")
+            mismatches.append(f"{path}: expected {architecture}, found {actual}")
+
+    if mismatches:
+        raise RuntimeError(
+            "Native Lambda package architecture mismatch:\n" + "\n".join(mismatches)
+        )
+    if not native_files:
+        raise RuntimeError(
+            "No native extensions were found; architecture verification did not exercise the compiled dependencies."
+        )
+    return native_files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("package", type=Path)
+    parser.add_argument("architecture", choices=sorted(EXPECTED_MACHINE))
+    args = parser.parse_args()
+
+    files = verify_package(args.package, args.architecture)
+    print(f"Verified {len(files)} native extensions for {args.architecture}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,5 +1,6 @@
 import json
 import os
+import struct
 import sys
 import tempfile
 import unittest
@@ -14,7 +15,8 @@ sys.path.insert(0, str(SCRIPTS))
 import bootstrap_oidc
 import configure_aws
 import restore_service
-from aws_setup import monitoring, storage, telegram_setup
+import verify_lambda_package
+from aws_setup import lambda_resources, monitoring, storage, telegram_setup
 
 
 class DeploymentPolicyTests(unittest.TestCase):
@@ -25,11 +27,11 @@ class DeploymentPolicyTests(unittest.TestCase):
             "arn:aws:iam::123456789012:role/existing-runtime-role",
         )
         statements = {statement["Sid"]: statement for statement in policy["Statement"]}
-        lambda_resources = statements["LambdaDeployment"]["Resource"]
+        lambda_policy_resources = statements["LambdaDeployment"]["Resource"]
         self.assertTrue(
             any(
                 resource.endswith(":function:ToEnWikipediaBotWorker")
-                for resource in lambda_resources
+                for resource in lambda_policy_resources
             )
         )
         self.assertIn(
@@ -44,6 +46,54 @@ class DeploymentPolicyTests(unittest.TestCase):
             "budgets:DescribeBudgets",
             statements["BudgetMonitoring"]["Action"],
         )
+
+
+class ArchitectureTests(unittest.TestCase):
+    def test_existing_lambda_is_migrated_to_arm64(self):
+        lambda_client = Mock()
+        lambda_client.get_function_configuration.side_effect = [
+            {"Architectures": ["x86_64"]},
+            {"Architectures": ["arm64"]},
+        ]
+        waiter = Mock()
+        lambda_client.get_waiter.return_value = waiter
+
+        result = lambda_resources._ensure_function_architecture(
+            lambda_client,
+            "ToEnWikipediaBot",
+        )
+
+        lambda_client.update_function_configuration.assert_called_once_with(
+            FunctionName="ToEnWikipediaBot",
+            Architectures=["arm64"],
+        )
+        waiter.wait.assert_called_once_with(FunctionName="ToEnWikipediaBot")
+        self.assertEqual(result["Architectures"], ["arm64"])
+
+    def test_arm64_elf_package_is_accepted(self):
+        with tempfile.TemporaryDirectory() as directory:
+            shared_object = Path(directory) / "extension.so"
+            header = bytearray(20)
+            header[:4] = b"\x7fELF"
+            header[5] = 1
+            struct.pack_into("<H", header, 18, 183)
+            shared_object.write_bytes(header)
+
+            files = verify_lambda_package.verify_package(Path(directory), "arm64")
+
+        self.assertEqual([path.name for path in files], ["extension.so"])
+
+    def test_x86_elf_is_rejected_from_arm64_package(self):
+        with tempfile.TemporaryDirectory() as directory:
+            shared_object = Path(directory) / "extension.so"
+            header = bytearray(20)
+            header[:4] = b"\x7fELF"
+            header[5] = 1
+            struct.pack_into("<H", header, 18, 62)
+            shared_object.write_bytes(header)
+
+            with self.assertRaisesRegex(RuntimeError, "expected arm64"):
+                verify_lambda_package.verify_package(Path(directory), "arm64")
 
 
 class DeploymentDiagnosticsTests(unittest.TestCase):


### PR DESCRIPTION
## ARM64 migration

- build Python 3.13 dependencies using AWS-compatible `manylinux2014_aarch64` wheels
- inspect every native ELF extension and fail CI if any x86_64 binary enters the ARM package
- use `ToEnWikipediaBotWorker` as a real ARM64 canary before changing the public webhook Lambda
- enforce `arm64` for the webhook, worker, and independent monitor functions
- preserve the existing Python 3.13 runtime and Function URL

## Safe rollback

- build both ARM64 and x86_64 known-good packages
- restore the package matching the function's current architecture before migration
- choose the architecture-compatible rollback package after any failed deployment stage
- keep Telegram's authenticated webhook restoration and existing diagnostic artifacts

## AWS permissions

The most recent production diagnostic showed that `GitHub_Deployer` cannot call `sqs:CreateQueue`. The workflow now stops before touching Lambda when GitHub OIDC cannot be bootstrapped, instead of attempting a rollout with insufficient credentials. `aws/github-deployer-oidc-bootstrap-policy.json` contains the one-time least-privilege policy needed to create the repository-scoped deployment role.

## Free-tier design

No always-on compute, NAT gateway, WAF, or provisioned concurrency is added. The existing small Lambda, SQS, DynamoDB, Scheduler, SNS, CloudWatch, and budget design is retained; ARM64 is selected for efficiency.

## Verification

- Python 3.13 unit and infrastructure tests
- dependency review
- ARM64 wheel build on every PR
- ELF architecture validation
- ARM worker invocation before live migration
- independent endpoint and Telegram webhook smoke test after provisioning